### PR TITLE
handling string 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ dkms.conf
 bin
 build
 temp
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC          = gcc
 LD          = gcc
 CFLAG       = -Wall -O3
+# CFLAG 		= -Wall -g3 # use for debugging
 PROG_NAME   = csv-split
 
 FILES_EXIST = ./scripts/files_exist.sh

--- a/src/flags.c
+++ b/src/flags.c
@@ -67,7 +67,7 @@ static size_t parse_flag_by_index(
       return *at += 2;  // Read extra argument.
     case EXCLUDE_HEADERS: cfg->exclude_headers = 1; return *at += 1;
     case LINE_COUNT:
-      if (at + 1 == argc) {
+      if (*(at + 1) == argc) {
         ERR_LOG("Expected line count. Use --help to learn more.\n");
         exit(PARSE_ERR);
       }
@@ -90,7 +90,7 @@ static size_t parse_flag_by_index(
       cfg->delimiter = argv[arg_at][0];
       return *at += 2;
     case REMOVE_COLUMNS:
-      if (at + 1 == argc) {  // Any string will be treated as a file name, as
+      if (*(at + 1) == argc) {  // Any string will be treated as a file name, as
         // lon as it's there.
         ERR_LOG("Expected file name. Use --help to learn more.\n");
         exit(PARSE_ERR);

--- a/src/split.c
+++ b/src/split.c
@@ -1,10 +1,12 @@
 #include "split.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
+bool open = false;
+#define mark_open_close(open) if (open == true) open = false; else open = true;
 #include "config.h"
 #include "log.h"
 
@@ -13,8 +15,13 @@
 static size_t strsub(char *str, const char old, const char new) {
   size_t count = 0;
   char *p;
+  const char ENCLOSED = '"';
+  open = false; //safety measure
   for (p = str; *p != '\0'; p++) {
-    if (*p == old) {
+    if (*p == ENCLOSED) {   //quick fix for handling enclosed columns
+      mark_open_close(open);
+    }
+    if (*p == old && open == false) {
       *p = new;
       count++;
     }

--- a/src/split.h
+++ b/src/split.h
@@ -1,8 +1,7 @@
 #ifndef SPLIT_H
 #define SPLIT_H
-
+#include <stdbool.h>
 #define FILE_NAME_SUFFIX_BUFFER 128
-
 #include "config.h"
 
 // Splits a CSV file based on the given config.


### PR DESCRIPTION
the column count versifier was not taking enclosed string columns as a single column and was splitting columns with ',' inside the string. I did a quick fix for it, Hope it's good enough, also some compiler warnings on flags.c about pointers being compared to none pointer types etc. 